### PR TITLE
Assignment1: Fix tini caller path.

### DIFF
--- a/dockerfile-assignment-1/Dockerfile
+++ b/dockerfile-assignment-1/Dockerfile
@@ -24,7 +24,7 @@
 # - then it needs to run 'npm install' to install dependencies from that file
 # - to keep it clean and small, run 'npm cache clean --force' after above
 # - then it needs to copy in all files from current directory
-# - then it needs to start container with command 'tini -- node ./bin/www'
+# - then it needs to start container with command '/sbin/tini -- node ./bin/www'
 # - in the end you should be using FROM, RUN, WORKDIR, COPY, EXPOSE, and CMD commands
 
 # Bonus Extra Credit


### PR DESCRIPTION
This is to avoid this warning

```
WARNING: Tini has been relocated to /sbin/tini.
Please update your scripts to use /sbin/tini going forward.
/usr/bin/tini has been preserved for backwards compatibility in Alpine 3.4,
but WILL BE REMOVED in Alpine 3.5.
```

Signed-off-by: Willy Sudiarto Raharjo <willysr@gmail.com>