### PR TITLE
fix(Dockerfile): ensure node server starts without any issues

### DIFF
--- a/dockerfile-assignment-1/Dockerfile
+++ b/dockerfile-assignment-1/Dockerfile
@@ -24,7 +24,7 @@
 # - then it needs to run 'npm install' to install dependencies from that file
 # - to keep it clean and small, run 'npm cache clean --force' after above
 # - then it needs to copy in all files from current directory
-# - then it needs to start container with command '/sbin/tini -- node ./bin/www'
+# - then it needs to start container with command '/sbin/tini -s -- node ./bin/www'
 # - in the end you should be using FROM, RUN, WORKDIR, COPY, EXPOSE, and CMD commands
 
 # Bonus Extra Credit


### PR DESCRIPTION
## Description:
Added "-s" parameter while starting the node server which solves TINI warning while starting the error

## Motivation:

I was having trouble starting my node server from the image I built using the dockerfile. So, I ran my container using `sh` as my starting command to debug this, and then tried manually starting the server using the command given in the Dockerfile. I was getting this error,

```
[WARN  tini (15)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
```

So, looking at the [readme] of tini, I got this solution.

## Testing:
My container ran fine after doing this change.

[readme]: https://github.com/krallin/tini