### PR TITLE
fixed deprecated gems configuration to plugins :: shows yellow warning on the terminal

### DIFF
--- a/bindmount-sample-1/_config.yml
+++ b/bindmount-sample-1/_config.yml
@@ -27,7 +27,7 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: minima
-gems:
+plugins:
   - jekyll-feed
 exclude:
   - Gemfile


### PR DESCRIPTION
Complete alert shown ::        
Deprecation:The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
#35 