### PR TITLE
Manually add webrick gem

### DIFF
--- a/bindmount-sample-1/Gemfile
+++ b/bindmount-sample-1/Gemfile
@@ -8,6 +8,8 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 gem "jekyll", "~> 4.1.0"
+# Manually add webrick gem.
+gem "webrick", "~> 1.7.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and


### PR DESCRIPTION
Adds gem dependency for ``webrick`` in: ``bindmount-sample-1/Gemfile``

Error caused when gem is not manually added:
``/usr/local/bundle/gems/jekyll-4.1.1/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)``
https://gist.github.com/PA4KEV/4315d2da046d20d71bdc5b11d63ef634