### PR TITLE
Adding missed out resources in Swarm lectures

### DIFF
--- a/swarm-stack-2/docker-compose.yml
+++ b/swarm-stack-2/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+services:
+  psql:
+    image: postgres
+    secrets:
+      - psql_user
+      - psql_password
+    environment:
+      - POSTGRES_USER_FILE=/run/secrets/psql_user
+      - POSTGRES_PASSWORD_FILE=/run/secrets/psql_password
+secrets:
+  psql_user:
+    file: ./psql_user.txt
+  psql_password:
+    file: ./psql_password.txt


### PR DESCRIPTION
Resources that belongs to lecture no 77 is missing. Hence adding it.