### PR TITLE
Fixing typo in compose-2.yml

### DIFF
--- a/compose-sample-1/compose-2.yml
+++ b/compose-sample-1/compose-2.yml
@@ -17,7 +17,7 @@ services:
       - ./wordpress-data:/var/www/html
 
   mysql:
-    # we sue mariadb here for arm support
+    # we use mariadb here for arm support
     # mariadb is a fork of MySQL that's often faster and better multi-platform
     image: mariadb
     environment:


### PR DESCRIPTION
Changed `sue` to `use` on line 20 in compose-sample-1/compose-2.yml