### PR TITLE
add --name flag to the dcoker run

### DIFF
--- a/compose-sample-1/docker-compose.yml
+++ b/compose-sample-1/docker-compose.yml
@@ -3,7 +3,7 @@
 # version: '2'
 
 # same as 
-# docker run -p 80:4000 -v $(pwd):/site bretfisher/jekyll-serve
+# docker run --name jekyll -p 80:4000 -v $(pwd):/site bretfisher/jekyll-serve
 
 services:
   jekyll:


### PR DESCRIPTION
We know the service names will be the DNS name in the docker engine networking. It will be a better simulation if we use the --name switch in the docker run for mapping service name in the compose yaml file.